### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock</groupId>
+    <groupId>jp.openam</groupId>
     <artifactId>forgerock-parent</artifactId>
     <version>2.0.3</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS. All rights reserved.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -22,7 +23,7 @@
     <version>2.0.3</version>
   </parent>
   <artifactId>forgerock-build-tools</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>ForgeRock Common Maven Build Tools</name>
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     This module includes common infrastructure required for building ForgeRock
     projects, comprising of TestNG listeners, Checkstyle configuration, etc.
   </description>
-  <url>http://commons.forgerock.org/forgerock-build-tools</url>
+  <url>https://github.com/openam-jp/forgerock-build-tools</url>
   <licenses>
     <license>
       <name>CDDL 1.0</name>
@@ -48,49 +48,11 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <distributionManagement>
-    <site>
-      <id>community.internal.forgerock.com</id>
-      <name>ForgeRock Community</name>
-      <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-build-tools</url>
-    </site>
-  </distributionManagement>
   <scm>
-    <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-build-tools.git</connection>
-    <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-build-tools.git</developerConnection>
-    <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-build-tools/browse</url>
+    <connection>scm:git:https://github.com/openam-jp/forgerock-build-tools.git</connection>
+    <developerConnection>scm:git:git@github.com:openam-jp/forgerock-build-tools.git</developerConnection>
+    <url>https://github.com/openam-jp/forgerock-build-tools</url>
   </scm>
-  <ciManagement>
-    <system>jenkins</system>
-    <url>http://builds.forgerock.org/job/Commons%20-%20ForgeRock%20Build%20Tools/</url>
-    <notifiers>
-      <notifier>
-        <type>mail</type>
-        <sendOnError>true</sendOnError>
-        <sendOnFailure>true</sendOnFailure>
-        <sendOnSuccess>false</sendOnSuccess>
-        <sendOnWarning>false</sendOnWarning>
-      </notifier>
-    </notifiers>
-  </ciManagement>
-  <repositories>
-    <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>http://maven.forgerock.org/repo/releases</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>forgerock-snapshots-repository</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>http://maven.forgerock.org/repo/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
   <build>
     <plugins>
       <plugin>
@@ -106,23 +68,6 @@
           <goals>deploy</goals>
           <arguments>-Penforce</arguments>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.forgerock.maven.plugins</groupId>
-        <artifactId>javadoc-updater-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <executions>
-          <execution>
-            <phase>site</phase>
-            <goals>
-              <goal>fixjavadoc</goal>
-            </goals>
-            <configuration>
-              <directory>${project.reporting.outputDirectory}</directory>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>jp.openam</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.7-SNAPSHOT</version>
   </parent>
   <artifactId>forgerock-build-tools</artifactId>
   <version>1.0.4-SNAPSHOT</version>


### PR DESCRIPTION
## Analysis
This project is Maven Build Tools for ForgeRock projects.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-build-tools
```

## Regression testing
N/A